### PR TITLE
durationが正しくモデルに入っていないバグを修正

### DIFF
--- a/app/models/concerns/video_duration.rb
+++ b/app/models/concerns/video_duration.rb
@@ -14,8 +14,15 @@ class VideoDuration
   private
 
     def duration_to_array(duration)
-      duration.split(/[A-Z]/).
-        map(&:to_i).
-        last(3)
+      hour = get_time(duration, "H")
+      min = get_time(duration, "M")
+      sec = get_time(duration, "S")
+      [hour, min, sec]
+    end
+
+    def get_time(duration, target)
+      regexp = Regexp.new("[0-9]+" + target)
+      items = duration.match(regexp)
+      items.blank? ? 0 : items[0].delete(target).to_i
     end
 end

--- a/app/models/concerns/video_duration.rb
+++ b/app/models/concerns/video_duration.rb
@@ -14,15 +14,11 @@ class VideoDuration
   private
 
     def duration_to_array(duration)
-      hour = get_time(duration, "H")
-      min = get_time(duration, "M")
-      sec = get_time(duration, "S")
-      [hour, min, sec]
+      %w[H M S].map { |time| get_time(duration, time) }
     end
 
     def get_time(duration, target)
-      regexp = Regexp.new("[0-9]+" + target)
-      items = duration.match(regexp)
-      items.blank? ? 0 : items[0].delete(target).to_i
+      items = duration.match(/[0-9]+#{target}/)
+      items.blank? ? 0 : items.to_s.delete(target).to_i
     end
 end

--- a/app/models/concerns/youtube.rb
+++ b/app/models/concerns/youtube.rb
@@ -5,7 +5,7 @@ class Youtube
 
   attr_reader :youtube_video_id,
               :channel_title,
-              :duration,
+              :time,
               :thumbnail_url,
               :published,
               :title
@@ -18,19 +18,8 @@ class Youtube
     @youtube_video_id = id
     @channel_title = result.snippet.channel_title
     @thumbnail_url = result.snippet.thumbnails.medium.url
-    @duration = VideoDuration.new(result.content_details.duration)
+    @time = VideoDuration.new(result.content_details.duration)
     @published = result.snippet.published_at
     @title = result.snippet.title
-  end
-
-  def create_params
-    [
-      [:youtube_video_id, @youtube_video_id],
-      [:channel_title, @channel_title],
-      [:thumbnail_url, @thumbnail_url],
-      [:duration, @duration.text],
-      [:published, @published],
-      [:title, @title],
-    ]
   end
 end

--- a/app/models/concerns/youtube.rb
+++ b/app/models/concerns/youtube.rb
@@ -30,7 +30,7 @@ class Youtube
       [:thumbnail_url, @thumbnail_url],
       [:duration, @duration.text],
       [:published, @published],
-      [:title, @title]
+      [:title, @title],
     ]
   end
 end

--- a/app/models/concerns/youtube.rb
+++ b/app/models/concerns/youtube.rb
@@ -22,4 +22,15 @@ class Youtube
     @published = result.snippet.published_at
     @title = result.snippet.title
   end
+
+  def create_params
+    [
+      [:youtube_video_id, @youtube_video_id],
+      [:channel_title, @channel_title],
+      [:thumbnail_url, @thumbnail_url],
+      [:duration, @duration.text],
+      [:published, @published],
+      [:title, @title]
+    ]
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -12,10 +12,11 @@ class Room < ApplicationRecord
 
     Video.create!(
       room: self,
+      duration: youtube.time.text,
       video_start_time: video_start_time,
-      video_end_time: youtube.duration.video_end_time(video_start_time),
+      video_end_time: youtube.time.video_end_time(video_start_time),
       add_user: user,
-      **youtube.create_params.to_h,
+      **youtube.to_h.except(:time),
     )
   end
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -12,11 +12,10 @@ class Room < ApplicationRecord
 
     Video.create!(
       room: self,
-      duration: youtube.duration.text,
       video_start_time: video_start_time,
       video_end_time: youtube.duration.video_end_time(video_start_time),
       add_user: user,
-      **youtube.to_h,
+      **youtube.create_params.to_h
     )
   end
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -15,7 +15,7 @@ class Room < ApplicationRecord
       video_start_time: video_start_time,
       video_end_time: youtube.duration.video_end_time(video_start_time),
       add_user: user,
-      **youtube.create_params.to_h
+      **youtube.create_params.to_h,
     )
   end
 

--- a/spec/models/concerns/video_duration_spec.rb
+++ b/spec/models/concerns/video_duration_spec.rb
@@ -14,14 +14,32 @@ describe VideoDuration do
     end
 
     context "when duration = 0:05:00" do
-      let(:arg) { "PT5M0S" }
+      let(:arg) { "PT5M" }
       let(:arg_second) { 5 * 60 }
       it { is_expected.to eq expectation }
     end
 
+    context "when duration = 0:05:05" do
+      let(:arg) { "PT5M5S" }
+      let(:arg_second) { 5 * 60 + 5 }
+      it { is_expected.to eq expectation }
+    end
+
     context "when duration = 5:00:00" do
-      let(:arg) { "PT5H0M0S" }
+      let(:arg) { "PT5H" }
       let(:arg_second) { 5 * 60 * 60 }
+      it { is_expected.to eq expectation }
+    end
+
+    context "when duration = 5:05:00" do
+      let(:arg) { "PT5H5M" }
+      let(:arg_second) { (5 * 60 + 5) * 60 }
+      it { is_expected.to eq expectation }
+    end
+
+    context "when duration = 5:00:05" do
+      let(:arg) { "PT5H5S" }
+      let(:arg_second) { 5 * 60 * 60 + 5 }
       it { is_expected.to eq expectation }
     end
   end
@@ -35,12 +53,12 @@ describe VideoDuration do
     end
 
     context "when duration = 0:05:00" do
-      let(:arg) { "PT5M0S" }
+      let(:arg) { "PT5M" }
       it { is_expected.to eq "5:00" }
     end
 
     context "when duration = 5:00:00" do
-      let(:arg) { "PT5H0M0S" }
+      let(:arg) { "PT5H" }
       it { is_expected.to eq "5:00:00" }
     end
   end
@@ -54,12 +72,12 @@ describe VideoDuration do
     end
 
     context "when duration = 0:05:00" do
-      let(:arg) { "PT5M0S" }
+      let(:arg) { "PT5M" }
       it { is_expected.to eq [0, 5, 0] }
     end
 
     context "when duration = 5:00:00" do
-      let(:arg) { "PT5H0M0S" }
+      let(:arg) { "PT5H" }
       it { is_expected.to eq [5, 0, 0] }
     end
   end


### PR DESCRIPTION
close #15 
二つほどバグがあったので潰しました
* youtube durationフォーマット認識ミスによるdurationが正しく計算されないバグ
* videoテーブルにdurationが正しく入らないバグ