### PR TITLE
絵文字が含まれると動画やチャットを追加できないバグ

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,9 @@
 #
 default: &default
   adapter: mysql2
-  encoding: utf8
+  charset: utf8mb4
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,7 +1,8 @@
 default: &default
   adapter: mysql2
-  encoding: utf8
-  collation: utf8_general_ci
+  charset: utf8mb4
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   reconnect: false
 
 test:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20171120013607) do
 
-  create_table "chats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "chats", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "room_id", null: false
     t.string "chat_type", null: false
     t.text "message", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20171120013607) do
     t.index ["user_id"], name: "index_chats_on_user_id"
   end
 
-  create_table "rooms", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "rooms", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "name", null: false
     t.string "key", null: false
     t.text "description"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20171120013607) do
     t.index ["key"], name: "index_rooms_on_key"
   end
 
-  create_table "user_room_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "user_room_logs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "user_id"
     t.bigint "room_id"
     t.datetime "entry_at", null: false
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20171120013607) do
     t.index ["user_id"], name: "index_user_room_logs_on_user_id"
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "name", default: "", null: false
@@ -64,7 +64,7 @@ ActiveRecord::Schema.define(version: 20171120013607) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "videos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "videos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.bigint "room_id", null: false
     t.string "youtube_video_id", null: false
     t.string "title"

--- a/spec/factories/chat.rb
+++ b/spec/factories/chat.rb
@@ -5,4 +5,11 @@ FactoryBot.define do
     room
     user
   end
+
+  factory :user_chat_with_emoji, class: Chat do
+    chat_type "user"
+    message "MyString💩"
+    room
+    user
+  end
 end

--- a/spec/models/chat_spec.rb
+++ b/spec/models/chat_spec.rb
@@ -1,9 +1,18 @@
 require "rails_helper"
 
 describe Chat do
-  it "is valid with correct param" do
-    chat = build(:user_chat)
-    expect(chat).to be_valid
+  context "with correct param" do
+    it "is valid" do
+      chat = create(:user_chat)
+      expect(chat).to be_valid
+    end
+  end
+
+  context "with emoji" do
+    it "is valid" do
+      chat = create(:user_chat_with_emoji)
+      expect(chat).to be_valid
+    end
   end
 
   describe "after_create_commit" do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -13,11 +13,22 @@ describe Room do
     subject { room.add_video youtube_video_id, user }
 
     let(:user) { build(:user) }
-    let(:youtube_video_id) { "XVId6EOnKq4" }
-    it "create video" do
-      expect { subject }.to change { Video.count }.by(1)
+
+    context "with valid params" do
+      let(:youtube_video_id) { "XVId6EOnKq4" }
+      it "create video" do
+        expect { subject }.to change { Video.count }.by(1)
+      end
+      it { expect(subject.youtube_video_id).to eq youtube_video_id }
     end
-    it { expect(subject.youtube_video_id).to eq youtube_video_id }
+
+    context "with emoji" do
+      let(:youtube_video_id) { "NasyGUeNMTs" }
+      it "create video" do
+        expect { subject }.to change { Video.count }.by(1)
+      end
+      it { expect(subject.youtube_video_id).to eq youtube_video_id }
+    end
   end
 
   describe "#calc_video_start_time" do


### PR DESCRIPTION
close #44 

絵文字付きのチャットも可能になりました。
サーバのDB設定を変更しないといけないけど。